### PR TITLE
#U53 fix: responsive for blogs paddings

### DIFF
--- a/components/layout/Layout.jsx
+++ b/components/layout/Layout.jsx
@@ -1,6 +1,9 @@
-export default function Layout({ styles, children }) {
+import React from 'react';
+
+export default React.forwardRef( function Layout({ styles, children},ref) {
     return (
         <section
+            ref={ref} 
             className={`px-5 mx-auto md:px-9 xl:px-16  xl:max-w-8xl ${
                 styles ? styles : " "
             }`}
@@ -8,4 +11,4 @@ export default function Layout({ styles, children }) {
             {children}
         </section>
     );
-}
+})

--- a/components/sections/blogs/Posts.jsx
+++ b/components/sections/blogs/Posts.jsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import Layout from "../../layout/Layout";
 import blogData from "/utils/blogData";
 import RightArrow from "../../vectors/Arrow";
-import RanderPost from "./RanderPosts";
+import RenderPost from "./RenderPosts";
 import { scrollBlogForward , scrollBlogBack } from "/utils/scrollBlog";
 
 export default function Posts() {
@@ -73,7 +73,7 @@ export default function Posts() {
         ref={mainWrapperRef}
         className={`relative flex max-w-full gap-6 p-6 px-5 overflow-x-auto  hide-scroll`}
       >
-        <RanderPost blogs={blogs} />
+        <RenderPost blogs={blogs} />
       </div>
     </section>
   );

--- a/components/sections/blogs/Posts.jsx
+++ b/components/sections/blogs/Posts.jsx
@@ -3,7 +3,8 @@ import { useEffect, useRef, useState } from "react";
 import Layout from "../../layout/Layout";
 import blogData from "/utils/blogData";
 import RightArrow from "../../vectors/Arrow";
-import RanderPost from "./RanderPosts"
+import RanderPost from "./RanderPosts";
+import { scrollBlogForward , scrollBlogBack } from "/utils/scrollBlog";
 
 export default function Posts() {
   const [blogs, setBlogs] = useState([]);
@@ -11,7 +12,9 @@ export default function Posts() {
   const [blogCounter, setBlogCounter] = useState(0);
   const [scrolled, setScrolled] = useState(false);
   const [scrollPosition, setScrollPosition] = useState(0);
+  const [spacing, setSpacing] = useState({});
   const mainWrapperRef = useRef();
+  const layout = useRef();
 
   const fetchBlogs = () => {
     setBlogCounter(blogCounter < blogLength ? blogCounter + 1 - 1 : 0);
@@ -20,53 +23,47 @@ export default function Posts() {
     setBlogs(blogClone);
   };
 
-  const triggerScroll = (mainWrapperRef) => {
+  const triggerScroll = () => {
     mainWrapperRef.current.addEventListener("scroll", (e) => {
       let scrollPosition = e.target.scrollLeft;
       setScrollPosition(scrollPosition);
-      let scrollablePx = Math.ceil(mainWrapperRef.current.scrollWidth) - Math.ceil(mainWrapperRef.current.offsetWidth);
-      if (scrollPosition >= scrollablePx) {
+      let scrollablePx = (mainWrapperRef.current.scrollWidth - mainWrapperRef.current.offsetWidth);
+      if (scrollPosition >= (scrollablePx - 90)) {
         fetchBlogs();
       }
     });
   };
 
-  const scrollBlogForward = () => {
-    fetchBlogs();
-    mainWrapperRef.current.scroll(scrollPosition + 1000, 0);
-  };
-
-  const scrollBlogBack = () => {
-    mainWrapperRef.current.scroll(
-      scrollPosition - 1000 <= 0 ? 0 : scrollPosition - 1000,
-      0
-    );
-  };
-
   useEffect(() => {
-    triggerScroll(mainWrapperRef);
+    triggerScroll();    
+    mainWrapperRef.current.style.paddingLeft = `calc(${spacing.marginLeft} + ${spacing.paddingLeft})`;
   }, [triggerScroll]);
 
   useEffect(() => {
     setBlogs(blogData);
     setBlogLength(blogData.length);
+    setSpacing(getComputedStyle(layout.current));
     mainWrapperRef.current.addEventListener("scroll", (e) => {
       e.target.scrollLeft > 200 ?  setScrolled(true) :  setScrolled(false);
     });
   }, []);
 
   return (
-    <div className="relative mx-auto xl:mb-25 md:mb-25.1 mb-34.7">
-      <Layout>
+    <section className="relative mx-auto xl:mb-25 md:mb-25.1 mb-34.7">
+      <Layout ref={layout} >
         <div className="flex items-center gap-4 mb-5">
           <h3 className="relative text-xl font-normal leading-8 text-muted-300 font-grotesk ">
             Blog
           </h3>
           <div className="relative items-center self-center hidden gap-2 mt-2 xl:flex">
-            <div className="rotate-180 cursor-pointer" onClick={scrollBlogBack}>
+            <div className="rotate-180 cursor-pointer" onClick={() => {
+              scrollBlogBack(mainWrapperRef,scrollPosition)
+            }}>
               <RightArrow stroke={!scrolled ? "#9A9A9A" : ""} />
             </div>
-            <div className="cursor-pointer" onClick={scrollBlogForward}>
+            <div className="cursor-pointer" onClick={() => {
+              scrollBlogForward(mainWrapperRef,scrollPosition)
+            }}>
               <RightArrow />
             </div>
           </div>
@@ -74,10 +71,10 @@ export default function Posts() {
       </Layout>
       <div
         ref={mainWrapperRef}
-        className="relative flex max-w-full gap-6 p-6 px-5 overflow-x-auto lg:px-16 md:px-9 hide-scroll"
+        className={`relative flex max-w-full gap-6 p-6 px-5 overflow-x-auto  hide-scroll`}
       >
         <RanderPost blogs={blogs} />
       </div>
-    </div>
+    </section>
   );
 }

--- a/components/sections/blogs/Posts.jsx
+++ b/components/sections/blogs/Posts.jsx
@@ -3,7 +3,8 @@ import { useEffect, useRef, useState } from "react";
 import Layout from "../../layout/Layout";
 import blogData from "/utils/blogData";
 import RightArrow from "../../vectors/Arrow";
-import RenderPost from "./RenderPosts";
+import RenderPost from "./RenderPost";
+
 import { scrollBlogForward , scrollBlogBack } from "/utils/scrollBlog";
 
 export default function Posts() {

--- a/components/sections/blogs/RanderPosts.jsx
+++ b/components/sections/blogs/RanderPosts.jsx
@@ -12,7 +12,7 @@ export default function RanderPost({ blogs }) {
                                 key={index}
                                 className="bg-muted-50 rounded-2.3xl px-2.5 py-01"
                             >
-                                <p className="text-lg font-normal text-muted-200">{value}</p>
+                                <p className="text-lg font-normal leading-4.2 text-muted-200 py-0.1 -tracking-lg">{value}</p>
                             </div>
                         ))}
                     </Blog>

--- a/components/sections/blogs/RenderPost.jsx
+++ b/components/sections/blogs/RenderPost.jsx
@@ -1,6 +1,6 @@
 import Blog from "../../ui/Blog";
 
-export default function RanderPost({ blogs }) {
+export default function RenderPost({ blogs }) {
     return(
         <>
             {blogs.map((value, index) => {

--- a/components/ui/Blog.jsx
+++ b/components/ui/Blog.jsx
@@ -9,7 +9,7 @@ function Blog({ date, title, description, children }) {
                 <p className="flex-grow pb-2 overflow-hidden text-xl font-normal leading-7 md:leading-8 -tracking-xsm max-h-41 text-ellipsis md:text-2xl md:-tracking-lg">
                     {description}
                 </p>
-                <div className="flex flex-wrap gap-x-3 gap-y-2">{children}</div>
+                <div className="flex flex-wrap gap-x-3 gap-y-2 mt-9.2">{children}</div>
             </div>
         </div>
     );

--- a/components/ui/Blog.jsx
+++ b/components/ui/Blog.jsx
@@ -1,7 +1,7 @@
 function Blog({ date, title, description, children }) {
     return (
         <div className="flex flex-col flex-grow-0 p-4 border min-w-xs md:min-w-sm md:max-w-sm min-h-90 md:p-5 lg:p-5 shadow-custom-sm border-muted-400 rounded-xl">
-            <h4 className="mb-6 text-lg text-muted-200">{date}</h4>
+            <h4 className="mb-6 text-lg leading-4.2 text-muted-200 -tracking-lg">{date}</h4>
             <div className="flex flex-col flex-grow gap-3">
                 <h2 className="text-2.9xl font-grotesk font-normal -tracking-xs leading-8.3 md:text-4xl md:leading-10.2">
                     {title}

--- a/components/ui/Blog.jsx
+++ b/components/ui/Blog.jsx
@@ -1,12 +1,12 @@
 function Blog({ date, title, description, children }) {
     return (
-        <div className="flex flex-col flex-grow-0 p-4 border  min-w-xs md:min-w-sm md:max-w-sm min-h-90 md:p-5 lg:p-5 shadow-custom-sm border-muted-400 rounded-xl">
+        <div className="flex flex-col flex-grow-0 p-4 border min-w-xs md:min-w-sm md:max-w-sm min-h-90 md:p-5 lg:p-5 shadow-custom-sm border-muted-400 rounded-xl">
             <h4 className="mb-6 text-lg text-muted-200">{date}</h4>
             <div className="flex flex-col flex-grow gap-3">
-                <h2 className="text-2.9xl font-grotesk font-normal -tracking-xs leading-8.3">
+                <h2 className="text-2.9xl font-grotesk font-normal -tracking-xs leading-8.3 md:text-4xl md:leading-10.2">
                     {title}
                 </h2>
-                <p className="flex-grow pb-2 overflow-hidden text-xl leading-7 -tracking-xsm max-h-41 text-ellipsis">
+                <p className="flex-grow pb-2 overflow-hidden text-xl font-normal leading-7 md:leading-8 -tracking-xsm max-h-41 text-ellipsis md:text-2xl md:-tracking-lg">
                     {description}
                 </p>
                 <div className="flex flex-wrap gap-x-3 gap-y-2">{children}</div>

--- a/components/ui/Blog.jsx
+++ b/components/ui/Blog.jsx
@@ -1,15 +1,15 @@
 function Blog({ date, title, description, children }) {
     return (
-        <div className=" flex-grow-0 min-w-xs md:min-w-sm  md:max-w-sm min-h-90 md:p-5 p-4 lg:p-5 shadow-custom-sm border border-muted-400 rounded-xl flex flex-col">
-            <h4 className="mb-6 text-muted-200 text-lg">{date}</h4>
-            <div className="flex flex-col gap-3 flex-grow">
+        <div className="flex flex-col flex-grow-0 p-4 border  min-w-xs md:min-w-sm md:max-w-sm min-h-90 md:p-5 lg:p-5 shadow-custom-sm border-muted-400 rounded-xl">
+            <h4 className="mb-6 text-lg text-muted-200">{date}</h4>
+            <div className="flex flex-col flex-grow gap-3">
                 <h2 className="text-2.9xl font-grotesk font-normal -tracking-xs leading-8.3">
                     {title}
                 </h2>
-                <p className="text-xl leading-7 flex-grow -tracking-xsm max-h-41 overflow-hidden text-ellipsis pb-2">
+                <p className="flex-grow pb-2 overflow-hidden text-xl leading-7 -tracking-xsm max-h-41 text-ellipsis">
                     {description}
                 </p>
-                <div className="flex gap-x-3 gap-y-2 flex-wrap">{children}</div>
+                <div className="flex flex-wrap gap-x-3 gap-y-2">{children}</div>
             </div>
         </div>
     );

--- a/components/ui/Blog.jsx
+++ b/components/ui/Blog.jsx
@@ -9,7 +9,7 @@ function Blog({ date, title, description, children }) {
                 <p className="flex-grow pb-2 overflow-hidden text-xl font-normal leading-7 md:leading-8 -tracking-xsm max-h-41 text-ellipsis md:text-2xl md:-tracking-lg">
                     {description}
                 </p>
-                <div className="flex flex-wrap gap-x-3 gap-y-2 mt-9.2">{children}</div>
+                <div className="flex flex-wrap gap-x-3 gap-y-2 mt-6 lg:mt-9.2">{children}</div>
             </div>
         </div>
     );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,6 +25,7 @@ module.exports = {
       },
       lineHeight: {
         8.3: "2.125rem",
+        10.2: "2.625rem",
         11: "4rem",
         12: "4.5rem",
         tighter: "1.125",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,6 +24,7 @@ module.exports = {
         },
       },
       lineHeight: {
+        4.2: "1.125rem",
         8.3: "2.125rem",
         10.2: "2.625rem",
         11: "4rem",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -110,9 +110,10 @@ module.exports = {
         xs: "25rem",
       },
       margin: {
+        9.2: "2.375rem",
         11.1: "3rem",
         11.2: "4.8125rem",
-        33: "8.25rem",
+        33: "8.25rem",        
       },
       padding: {
         0.1: "0.1875rem",

--- a/utils/blogData.js
+++ b/utils/blogData.js
@@ -8,7 +8,7 @@ const blogData = [
             deploy an open protocol for decentralized working 
             capital and MSME financial solutions across Africa.        
         `,
-        tags:["Blockchain","DAOs","Decentralization"]
+        tags:["Blockchain","DAOs","Decentralization","Blockchain","DAOs","Decentralization"]
     },
     {
         id: 2,

--- a/utils/blogData.js
+++ b/utils/blogData.js
@@ -49,6 +49,57 @@ const blogData = [
             be a new, better version of the internet.        
         `,
         tags:["Blockchain","DAOs","Decentralization"]
+    },
+    {
+        id: 7,
+        date: "02 Oct 2022",
+        title: "Launch of the Africa DeFi Alliance DAO",
+        description: `
+            An auspicious group of like-minded partners will
+            deploy an open protocol for decentralized working 
+            capital and MSME financial solutions across Africa.        
+        `,
+        tags:["Blockchain","DAOs","Decentralization"]
+    },
+    {
+        id: 8,
+        date: "02 Oct 2022",
+        title: "What's Wrong with Ethereum?",
+        description: `
+            Isn't blockchain open for everybody to use? Why
+            do I have to pay to make transactions?        
+        `,
+        tags:["Blockchain","DAOs","Decentralization"]
+    },
+    {
+        id: 9,
+        date: "02 Oct 2022",
+        title: "What is Ethereum, and Why is it Special?",
+        description: `
+            Ethereum (and web3 more generally) was designed to 
+            be a new, better version of the internet.        
+        `,
+        tags:["Blockchain","DAOs","Decentralization"]
+    },
+    {
+        id: 10,
+        date: "02 Oct 2022",
+        title: "What is Ethereum, and Why is it Special?",
+        description: `
+            Ethereum (and web3 more generally) was designed to 
+            be a new, better version of the internet.        
+        `,
+        tags:["Blockchain","DAOs","Decentralization"]
+    },
+    {
+        id: 11,
+        date: "02 Oct 2022",
+        title: "What is Ethereum, and Why is it Special?",
+        description: `
+            Ethereum (and web3 more generally) was designed to 
+            be a new, better version of the internet.        
+        `,
+        tags:["Blockchain","DAOs","Decentralization"]
     }
 ]
 

--- a/utils/scrollBlog.js
+++ b/utils/scrollBlog.js
@@ -1,0 +1,10 @@
+export const scrollBlogForward = (ref,scrollPosition) => {
+    ref.current.scroll(scrollPosition + 1000, 0);
+};
+
+export const scrollBlogBack = (ref,scrollPosition) => {
+    ref.current.scroll(
+        scrollPosition - 1000 <= 0 ? 0 : scrollPosition - 1000,
+        0
+    );
+};


### PR DESCRIPTION
# PR Description

This pull request aims to make the blog section more responsive on different screen

# Description of tasks that were expected to be completed


- [x]  the Blog slider should be aligned with the Blog text Note that: when you start swiping/sliding/scrolling to the right, blogs should span across the whole screen width


# Description of tasks that were expected to be completed and that are not yet completed


- [x] `none`

# How this may be tested?

1. Run `npm i` to install all required dependencies;
2. Run `npm run dev`  
3. You can now navigate to localhost:port
4. During responsiveness validation make sure when you resize the screen whenever you change the screen 

# Screenshots (If appropriate/applicable)

Provide screenshots related to your PR in case it's appropriate and applicable

# Please check this Checklist before you submit your PR:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My code generates no warnings
- [x] There are no vulnerabilities 

